### PR TITLE
Add tests for new MCP API endpoints

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -133,3 +133,75 @@ def test_handle_tools_call_error(mock_send_result):
     args, _ = mock_send_result.call_args
     assert args[0]["isError"] is True
     assert "Test error" in args[0]["content"][0]["text"]
+
+
+@patch("src.mcp_server.MCPServer._send_result")
+def test_handle_notifications_initialized(mock_send_result):
+    """notifications/initializedメソッドの処理をテストします"""
+    server = MCPServer()
+
+    # notifications/initializedメソッドを呼び出し
+    params = {}
+    request_id = 1
+    server._handle_notifications_initialized(params, request_id)
+
+    # request_idが指定されている場合、_send_resultが呼び出されることを確認
+    mock_send_result.assert_called_once_with({}, request_id)
+
+    # request_idがNoneの場合、_send_resultが呼び出されないことを確認
+    mock_send_result.reset_mock()
+    server._handle_notifications_initialized(params, None)
+    mock_send_result.assert_not_called()
+
+
+@patch("src.mcp_server.MCPServer._send_result")
+@patch("src.mcp_server.MCPServer._get_resources")
+def test_handle_resources_list(mock_get_resources, mock_send_result):
+    """resources/listメソッドの処理をテストします"""
+    server = MCPServer()
+
+    # モックの戻り値を設定
+    mock_resources = [{"name": "test_resource", "uri": "test://resource"}]
+    mock_get_resources.return_value = mock_resources
+
+    # resources/listメソッドを呼び出し
+    request_id = 1
+    server._handle_resources_list(request_id)
+
+    # _get_resourcesが呼び出されることを確認
+    mock_get_resources.assert_called_once()
+
+    # _send_resultが正しく呼び出されていることを確認
+    mock_send_result.assert_called_once_with({"resources": mock_resources}, request_id)
+
+
+@patch("src.mcp_server.MCPServer._send_result")
+@patch("src.mcp_server.MCPServer._get_resource_templates")
+def test_handle_resources_templates_list(mock_get_resource_templates, mock_send_result):
+    """resources/templates/listメソッドの処理をテストします"""
+    server = MCPServer()
+
+    # モックの戻り値を設定
+    mock_templates = [{"name": "test_template", "schema": {}}]
+    mock_get_resource_templates.return_value = mock_templates
+
+    # resources/templates/listメソッドを呼び出し
+    request_id = 1
+    server._handle_resources_templates_list(request_id)
+
+    # _get_resource_templatesが呼び出されることを確認
+    mock_get_resource_templates.assert_called_once()
+
+    # _send_resultが正しく呼び出されていることを確認
+    mock_send_result.assert_called_once_with({"templates": mock_templates}, request_id)
+
+
+def test_get_resource_templates():
+    """_get_resource_templatesメソッドをテストします"""
+    server = MCPServer()
+
+    # _get_resource_templatesメソッドを呼び出し
+    templates = server._get_resource_templates()
+
+    # 空のリストが返されることを確認
+    assert templates == []


### PR DESCRIPTION
## 変更内容

新しく追加されたMCP APIエンドポイントに対するテストを追加しました：

## 変更理由

PR #5で追加されたAPIエンドポイントに対するテストがなかったため、テストカバレッジを向上させるために追加しました。

## 影響範囲

- [x] 既存の機能への影響（テストの追加のみ）
- [ ] パフォーマンスへの影響
- [ ] セキュリティへの影響

## 動作確認

- [x] ユニットテストの追加・更新
- [x] 動作確認の実施
- [ ] ドキュメントの更新（不要）