### PR TITLE
Fix import error in main.py

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -13,7 +13,6 @@ import logging
 from dotenv import load_dotenv
 
 from .mcp_server import MCPServer
-from .example_tool import register_example_tools
 from .rag_tools import register_rag_tools, create_rag_service_from_env
 
 
@@ -55,9 +54,6 @@ def main():
     try:
         # MCPサーバーの作成
         server = MCPServer()
-
-        # サンプルツールの登録
-        register_example_tools(server)
 
         # RAGサービスの作成と登録
         logger.info("RAGサービスを初期化しています...")


### PR DESCRIPTION
## 概要
削除された example_tool モジュールのインポートエラーを修正しました。

## 修正内容
- src/main.py から削除された example_tool モジュールのインポートを削除
- register_example_tools 関数の呼び出しを削除
- MCPサーバー起動時の ModuleNotFoundError を解決

## 動作確認
- ✅ テスト: 全9件パス
- ✅ CLIツール: インデックス化とカウント機能が正常動作  
- ✅ MCPサーバー: 正常に起動することを確認

## 関連Issue
前回のPR #7 で example_tool.py を削除した際の残存参照を修正